### PR TITLE
Add prerequisites.sh file for compiling nauty

### DIFF
--- a/prerequisites.sh
+++ b/prerequisites.sh
@@ -1,0 +1,3 @@
+set -e
+PKG_DIR=`dirname "$0"`
+cd $PKG_DIR/nauty2*r* && ./configure && make


### PR DESCRIPTION
This should let GAP's `BuildPackages.sh` script properly compile this package from a git clone.