### PR TITLE
Fix crash for empty graphs

### DIFF
--- a/src/NautyTracesInterface.c
+++ b/src/NautyTracesInterface.c
@@ -95,8 +95,7 @@ static Obj FuncNAUTY_GRAPH(Obj self,
     m = SETWORDSNEEDED(n);
     //     DYNALLOC2(graph,g,g_sz,m,n,"malloc");
     g_sz = m * n;
-    g = (graph *)malloc(g_sz * sizeof(graph));
-    EMPTYGRAPH(g, m, n);
+    g = (graph *)calloc(g_sz, sizeof(graph));
     len_source = LEN_PLIST(source_list);
     len_range = LEN_PLIST(range_list);
     if (len_source != len_range) {
@@ -169,7 +168,8 @@ FuncNAUTY_DENSE(Obj self, Obj nauty_graph, Obj is_directed, Obj color_data)
     DYNALLOC1(int, ptn, ptn_sz, n, "malloc");
     DYNALLOC1(int, orbits, orbits_sz, n, "malloc");
 
-    EMPTYGRAPH(cg, m, n);
+    if (m > 0 && n > 0)
+        EMPTYGRAPH(cg, m, n);
 
     if (color_data != False) {
 
@@ -263,7 +263,8 @@ static Obj FuncNAUTY_DENSE_REPEATED(Obj self,
     DYNALLOC1(int, ptn, ptn_sz, n, "malloc");
     DYNALLOC1(int, orbits, orbits_sz, n, "malloc");
 
-    EMPTYGRAPH(cg, m, n);
+    if (m > 0 && n > 0)
+        EMPTYGRAPH(cg, m, n);
 
     Obj return_list = NEW_PLIST(T_PLIST, LEN_PLIST(color_data));
     SET_LEN_PLIST(return_list, LEN_PLIST(color_data));

--- a/tst/test.tst
+++ b/tst/test.tst
@@ -28,3 +28,19 @@ gap> pet_range := pet_nauty[ 2 ];
 gap> NautyDense( pet_source, pet_range, 10, false, false );
 [ [ (2,4)(6,9)(7,10), (2,6)(4,9)(5,8), (2,6,10)(3,5,8)(4,9,7), 
       (1,2,3,5,7)(4,6,8,9,10) ], (2,3,5,7)(4,8,9,6,10) ]
+
+# some graphs without edges, including the empty graph
+gap> NautyDense( [], [], 0, false, false );
+[ [  ], () ]
+gap> NautyDense( [], [], 1, false, false );
+[ [  ], () ]
+gap> NautyDense( [], [], 2, false, false );
+[ [ (1,2) ], () ]
+
+# some graphs without edges, including the empty graph
+gap> NautyDense( [], [], 0, true, false );
+[ [  ], () ]
+gap> NautyDense( [], [], 1, true, false );
+[ [  ], () ]
+gap> NautyDense( [], [], 2, true, false );
+[ [ (1,2) ], () ]


### PR DESCRIPTION
The EMPTYGRAPH writes out-of-bounds for empty graphs.

Fixes #17