### PR TITLE
Fix broken reference to Section_NautyGraph

### DIFF
--- a/gap/NautyGraph.gd
+++ b/gap/NautyGraph.gd
@@ -10,7 +10,7 @@
 #! @ChapterLabel NautyGraphs
 #!
 #! @Section Working with Nauty Graphs 
-#! @SectionLabel Section_NautyGraph
+#! @SectionLabel NautyGraph
 
 DeclareCategory( "IsNautyGraph",
                  IsObject );


### PR DESCRIPTION
The `@SectionLabel` command prepends `Section_`, making the label `Section_Section_NautyGraph`, which doesn't match the Ref below, leading to:
```
#W WARNING: non resolved reference: rec(
  Sect := "Section_NautyGraph" )
```
