### PR TITLE
Update CI to use setup-gap@v3, add missing dependencies

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -35,8 +35,6 @@ jobs:
         with:
           gap-version: ${{ matrix.gap-version }}
       - uses: gap-actions/build-pkg@v3
-        with:
-          extra-pkgs: "io orb profiling datastructures digraphs grape"
       - uses: gap-actions/run-pkg-tests@v4
       - uses: gap-actions/run-pkg-tests@v4
         with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,31 +19,29 @@ concurrency:
 jobs:
   # The CI test job
   test:
-    name: ${{ matrix.gap-branch }}
+    name: ${{ matrix.gap-version }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        gap-branch:
-          - master
-          - stable-4.16
-          - stable-4.15
-          - stable-4.14
-          - stable-4.13
-          - stable-4.12
+        gap-version:
+          - 'devel'   # current GAP development version from git
+          - 'latest'  # latest GAP release
+          - 'minimal' # oldest GAP release supported by this package
 
     steps:
       - uses: actions/checkout@v6
-      - uses: gap-actions/setup-gap@v2
+      - uses: gap-actions/setup-gap@v3
         with:
-          GAP_PKGS_TO_BUILD: "io orb profiling datastructures digraphs grape"
-          GAPBRANCH: ${{ matrix.gap-branch }}
-      - uses: gap-actions/build-pkg@v1
-      - uses: gap-actions/run-pkg-tests@v3
-      - uses: gap-actions/run-pkg-tests@v3
+          gap-version: ${{ matrix.gap-version }}
+      - uses: gap-actions/build-pkg@v3
         with:
-          only-needed: true
-      - uses: gap-actions/process-coverage@v2
+          extra-pkgs: "io orb profiling datastructures digraphs grape"
+      - uses: gap-actions/run-pkg-tests@v4
+      - uses: gap-actions/run-pkg-tests@v4
+        with:
+          mode: onlyneeded
+      - uses: gap-actions/process-coverage@v3
       - uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -73,8 +73,9 @@ PackageDoc := rec(
 
 Dependencies := rec(
   GAP := ">= 4.12",
-  NeededOtherPackages := [ [ "GAPDoc", ">= 1.5" ] ],
+  NeededOtherPackages := [ [ "digraphs", ">= 1.6" ] ],
   SuggestedOtherPackages := [ ],
+  TestPackages := [ [ "grape", ">= 4.9.0" ] ],
   ExternalConditions := [ ],
 ),
 

--- a/gap/NautyGraph.gd
+++ b/gap/NautyGraph.gd
@@ -402,3 +402,5 @@ DeclareGlobalFunction( "CREATE_NAUTY_GRAPH_OBJECT" );
 DeclareGlobalFunction( "CREATE_NAUTY_EDGE_COLORED_GRAPH" );
 
 
+##
+DeclareGlobalFunction( "NautyDense" );

--- a/gap/NautyGraph.gi
+++ b/gap/NautyGraph.gi
@@ -436,7 +436,7 @@ end );
 
 
 #! TODO: document this
-BindGlobal( "NautyDense",
+InstallGlobalFunction( "NautyDense",
 function( source_list, range_list, n, is_directed, color_data )
     local graph;
     graph := NAUTY_GRAPH( source_list, range_list, n, is_directed );


### PR DESCRIPTION
Update the CI workflow to use current gap-actions releases, migrate legacy inputs, and standardize the GAP version matrix.